### PR TITLE
Added ETH address for Ryan Pereira from LandBrokes

### DIFF
--- a/double-opt-in-credit/LandBrokes/submission.md
+++ b/double-opt-in-credit/LandBrokes/submission.md
@@ -20,7 +20,7 @@ Contact Team Member about Future Hackathons? y julesgoullee@gmail.com
 
 Ryan Pereira
 @pereiraryan
-Please contact on email for ETH address
+0xb67ECd2e31f9F42c309aecD714cb0e4e1B8E152c
 Contact Team Member about Future Hackathons? y pereiraryan.rp@gmail.com
 
 Stefan-Codrin Ionescu

--- a/financial-reputation/LandBrokes/submission.md
+++ b/financial-reputation/LandBrokes/submission.md
@@ -20,7 +20,7 @@ Contact Team Member about Future Hackathons? y julesgoullee@gmail.com
 
 Ryan Pereira
 @pereiraryan
-Please contact on email for ETH address
+0xb67ECd2e31f9F42c309aecD714cb0e4e1B8E152c
 Contact Team Member about Future Hackathons? y pereiraryan.rp@gmail.com
 
 Stefan-Codrin Ionescu


### PR DESCRIPTION
In LandBrokes we did not have the ETH address for Ryan Pereira because yesterday he was offline and could not give it.